### PR TITLE
Pure JSON code

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,6 @@ var keyboard = kle.Serial.deserialize([
   { name: "Sample", author: "Your Name" },
   ["Q", "W", "E", "R", "T", "Y"]
 ]);
-
-// or
-
-var keyboard = kle.Serial.parse(`[
-  { name: "Sample", author: "Your Name" },
-  ["Q", "W", "E", "R", "T", "Y"]
-]`);
 ```
 
 ## API
@@ -58,16 +51,6 @@ kle.Serial.deserialize(rows: Array<any>): Keyboard
 - Given an array of keyboard rows, deserializes the result into a `Keyboard`
   object.
 - The first entry is optionally a keyboard metadata object.
-
-```ts
-kle.Serial.parse(json5: string): Keyboard
-```
-
-- This function takes a JSON5-formatted string, parses it, then deserializes the
-  result into a `Keyboard` object.
-- [JSON5](https://json5.org/) is a simplified / lenient version of JSON that is
-  easier for humans to type; in particular, it doesn't require quotes around
-  property names. Any valid JSON string should also be a valid JSON5 string.
 
 ### Keyboard Objects
 

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,3 @@
-import * as JSON5 from "json5";
-
 export class Key {
   color: string = "#cccccc";
   labels: string[] = [];
@@ -92,7 +90,7 @@ export module Serial {
   }
 
   function deserializeError(msg, data?) {
-    throw "Error: " + msg + (data ? ":\n  " + JSON5.stringify(data) : "");
+    throw "Error: " + msg + (data ? ":\n  " + JSON.stringify(data) : "");
   }
 
   export function deserialize(rows: Array<any>): Keyboard {
@@ -206,6 +204,6 @@ export module Serial {
   }
 
   export function parse(json: string): Keyboard {
-    return deserialize(JSON5.parse(json));
+    return deserialize(JSON.parse(json));
   }
 }

--- a/index.ts
+++ b/index.ts
@@ -202,8 +202,4 @@ export module Serial {
     }
     return kbd;
   }
-
-  export function parse(json: string): Keyboard {
-    return deserialize(JSON.parse(json));
-  }
 }

--- a/package.json
+++ b/package.json
@@ -33,8 +33,5 @@
     "mocha": "^6.1.4",
     "mocha-lcov-reporter": "^1.3.0",
     "typescript": "^3.5.3"
-  },
-  "dependencies": {
-    "json5": "^2.1.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -449,31 +449,4 @@ describe("deserialization", function() {
       expect(result.keys[2].textSize[6]).to.equal("2");
     });
   });
-
-  describe("of strings", function() {
-    it("should be lenient about quotes", function() {
-      var result1 = () =>
-        kbd.Serial.parse(`[
-        { name: "Sample", author: "Your Name" },
-        ["Q", "W", "E", "R", "T", "Y"]
-      ]`);
-
-      var result2 = () =>
-        kbd.Serial.parse(`[
-        { "name": "Sample", "author": "Your Name" },
-        ["Q", "W", "E", "R", "T", "Y"]
-      ]`);
-
-      var result3 = () =>
-        kbd.Serial.deserialize([
-          { name: "Sample", author: "Your Name" },
-          ["Q", "W", "E", "R", "T", "Y"]
-        ]);
-
-      expect(result1).to.not.throw();
-      expect(result2).to.not.throw();
-      expect(result1(), "1<>2").to.deep.equal(result2());
-      expect(result1(), "1<>3").to.deep.equal(result3());
-    });
-  });
 });


### PR DESCRIPTION
JSON5 is cool for what it is, but not sure it's a mandatory requirement for this package--and having it "in the way" was meaning lots of build overhead to use kle-serial in a browser.

Consequently, these two commits...
1. Remove JSON5 as a dependency.
2. Remove the `.parse()` method altogether as it can (should?) be done at an application layer if/when needed (+/- JSON5 support if that's wanted).

This then focuses this library on just deserialization. Huzzah! 😀 

Thanks for building this and [KLE](keyboard-layout-editor.com/)!
🎩 